### PR TITLE
Implement Action and Mutation subscribers

### DIFF
--- a/app-example/src/App.vue
+++ b/app-example/src/App.vue
@@ -108,8 +108,8 @@ input {
 }
 
 #footer {
-  position: absolute;
-  bottom: 10px;
+  position: relative;
+  margin-top: 15px;
   left: 0;
   right: 0;
 }

--- a/app-example/src/store.js
+++ b/app-example/src/store.js
@@ -18,6 +18,14 @@ const myVueWatcher = new VueWatcher({
     {
       getter: 'getactive',
       cb: (val) => console.log(`Running getters' "getactive" callback \nValue: ${val}`)
+    },
+    {
+      action: 'toggle',
+      cb: () => console.log('Running action subscribe callback')
+    },
+    {
+      mutation: 'UPDATE_TEXT',
+      cb: () => console.log('Running subscribe callback')
     }
   ]
 })

--- a/src/README.md
+++ b/src/README.md
@@ -55,20 +55,24 @@ _An in-depth example application can be found within /example folder of this rep
 
 ### General Usage
 ```javascript
-import VueWatcher from 'vuex-watcher';
-const myVueWatcher = new VueWatcher({
+import VuexWatcher from 'vuex-watcher';
+
+const watcherPlugin = new VuexWatcher({
   environment: 'development',
   watches: [
     {
       getter: 'getactive',
-      cb: (val) => console.log(`Running getters' "getMsg" callback => ${val}`)
+      cb: (val, oldVal) => console.log(`Running getters "getMsg" callback => Was: ${oldVal}, Now: ${val}`)
     }
   ]
-})
+});
+
+store.commit('UPDATE_TEXT', 'It is Day.')
+// Outputs: Running getters "getMsg" callback => Was: Night, Now: It is day.
 
 export default new Vuex.Store({
-  plugins: [myVueWatcher]
-})
+  plugins: [watcherPlugin]
+});
 ```
 
 ### Environment
@@ -84,27 +88,35 @@ Options: 'development', 'production'
 
 ### Watcher Types
 
-#### State
+#### Actions
 ```javascript
 {
-  watches: [
-    {
-      state: 'text',
-      cb: (val) => console.log(`Running state "text" callback => ${val}`)
-    }
-  ]
+  action: 'myAction',
+  cb: (payload, preState) => { /* logic */ }
 }
 ```
 
 #### Getters
 ```javascript
 {
-  watches: [
-    {
-      getter: 'getactive',
-      cb: (val) => console.log(`Running getters "getMsg" callback => ${val}`)
-    }
-  ]
+  getter: 'getactive',
+  cb: (val, oldVal) => console.log(`Running getters "getMsg" callback => Was: ${oldVal}, Now: ${val}`)
+}
+```
+
+#### Mutation
+```javascript
+{
+  mutation: 'UPDATE_TEXT',
+  cb: (payload, postState) => { /* logic */ }
+}
+```
+
+#### State
+```javascript
+{
+  state: 'text',
+  cb: (val, oldVal) => console.log(`Running state "text" callback => Was: ${oldVal}, Now: ${val}`)
 }
 ```
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,10 @@
+/**
+ * Directory of errors for use throughout the package
+ */
+
+export class VuexWatcherError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = 'VuexWatcherError';
+  }
+}

--- a/src/kernel/index.js
+++ b/src/kernel/index.js
@@ -1,0 +1,14 @@
+import { EventEmitter } from 'events';
+import { WatcherLogger } from '../logger';
+
+export class WatcherKernel extends EventEmitter {
+  constructor(ModuleOpts) {
+    super();
+    this.env_ = ModuleOpts.environment;
+    this.logger = new WatcherLogger();
+  }
+
+  isLogFriendly() {
+    return !(this.env_ === 'production');
+  }
+}

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -1,8 +1,6 @@
-
-export default class VueWatcherLogger {
+export class WatcherLogger {
   constructor() {
-    this.pluginID = '[Vue-Watcher]'
-    return
+    this.pluginID = '[Vuex-Watcher]'
   }
 
   warn (msg) {
@@ -10,10 +8,14 @@ export default class VueWatcherLogger {
   }
 
   error (err) {
-    throw new Error(`${this.pluginID} ${err}`)
+    console.error(this.pluginID, err)
   }
 
   log (msg) {
     console.warn(this.pluginID, msg)
+  }
+
+  info(msg) {
+    console.log('%c %s %s ', 'color: #2366EC;', this.pluginID, msg);
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,10 @@
+/**
+ * Module directory of types
+ */
+
+export const EventTypes = {
+  Action: 'subscribeAction',
+  Getter: 'getters',
+  Mutation: 'subscribe',
+  State: 'state'
+};

--- a/src/watchers/index.js
+++ b/src/watchers/index.js
@@ -1,0 +1,69 @@
+import Watcher from './watcher';
+import { EventTypes } from '../types';
+
+export class Watchers {
+  constructor(watcherArgs) {
+    this._watchers = [...watcherArgs].
+      map((watcher) => new Watcher(watcher));
+  }
+
+  getInvalidArgs() {
+    const invalid = [];
+
+    const watchers = this._watchers
+    for (let i = 0; i < watchers.length; i++) {
+
+      switch (watchers[i].type) {
+        case EventTypes.Action:
+          /* Setup for support of {vuex: ^3.1.0} where you can specify
+          an action callback `before` or `after` it occurs */
+
+          // const keys = watchers[i].keys
+          // const numKeys = keys.length;
+          // if (numKeys === 1 && keys[0] !== EventTypes.Action) {
+          //   invalid.push(watchers[i]);
+          // } else if (
+          //   (
+          //     numKeys >= 3 && numKeys < 1
+          //   ) &&
+          //   (
+          //     !keys.includes('before') || !keys.includes('after')
+          //   )
+          // ) {
+          //   invalid.push(watchers[i]);
+          // }
+          // break;
+        case EventTypes.Getter:
+        case EventTypes.Mutation:
+        case EventTypes.State:
+        default:
+          if (watchers[i].keys.length > 1) {
+            invalid.push(watchers[i]);
+          }
+          break;
+      }
+    }
+
+    return invalid;
+  }
+
+  get all() {
+    return this._watchers;
+  }
+
+  get actions() {
+    return this._watchers.filter(({ type }) => type === EventTypes.Action);
+  }
+
+  get fields() {
+    return this._watchers.filter(({ type }) => type === EventTypes.State);
+  }
+
+  get getters() {
+    return this._watchers.filter(({ type }) => type === EventTypes.Getter);
+  }
+
+  get mutations() {
+    return this._watchers.filter(({ type }) => type === EventTypes.Mutation);  
+  }
+}

--- a/src/watchers/watcher.js
+++ b/src/watchers/watcher.js
@@ -1,0 +1,34 @@
+import { EventTypes } from "../types";
+
+export default class Watcher {
+  constructor(watcher) {
+    const watcherKeys = Object.keys(watcher).
+      filter((key) => key !== 'cb');
+
+    this._watcherType = EventTypes[
+      watcherKeys[0].charAt(0).toUpperCase() + watcherKeys[0].substring(1)
+    ];
+    this._watcherName = watcher[watcherKeys[0]];
+    this._rawListener = watcher;
+  }
+
+  get name() {
+    return this._watcherName;
+  }
+
+  get type() {
+    return this._watcherType
+  }
+
+  get cb() {
+    return this._rawListener.cb;
+  }
+
+  get raw() {
+    return this._rawListener;
+  }
+
+  get keys() {
+    return Object.keys(this.raw).filter((key) => key !== 'cb');
+  }
+}


### PR DESCRIPTION
- Updated the lib to follow more of an OOP design.
- Now supports `{ action: "myAction" }` and `{ mutation: "myMutation" }` watchers:
  - Both an `action` and `mutation` callback function is passed two arguments: the event's `payload` and the store's `state` _before_ the action occurs and _after_ the mutation occurs.


I didn't think it was worth including the action or mutation `type` in the watcher's callback because when defining the watcher, `type` -  the specific action or mutation name for which to invoke the callback - is already known.